### PR TITLE
[AsyncStreaming] Add bidirectional adapters for the async writers

### DIFF
--- a/Sources/AsyncStreaming/AsyncWriter/AsyncWriterCallerAsyncWriterAdapter.swift
+++ b/Sources/AsyncStreaming/AsyncWriter/AsyncWriterCallerAsyncWriterAdapter.swift
@@ -1,0 +1,98 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Async Algorithms open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if UnstableAsyncStreaming && compiler(>=6.4)
+public import ContainersPreview
+
+/// A ``CallerAsyncWriter`` that is implemented in terms of an
+/// ``AsyncWriter``.
+///
+/// Each ``write(buffer:)`` call drains the caller's buffer through one
+/// or more ``AsyncWriter/write(_:)`` closures on the underlying writer.
+/// When the underlying writer's buffer fills before the caller's empties,
+/// the adapter loops with another closure call to continue draining.
+///
+/// The adapter introduces no buffer of its own — elements move directly
+/// from the caller-supplied buffer into the underlying writer's
+/// closure-supplied buffer. The underlying writer's deferred-flush
+/// behavior, if any, is preserved.
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+public struct AsyncWriterCallerAsyncWriterAdapter<
+  Underlying: AsyncWriter & ~Copyable
+>: ~Copyable, CallerAsyncWriter {
+  public typealias WriteElement = Underlying.WriteElement
+  public typealias WriteFailure = Underlying.WriteFailure
+  public typealias FinalElement = Underlying.FinalElement
+
+  @usableFromInline
+  var underlying: Underlying
+
+  @inlinable
+  init(underlying: consuming Underlying) {
+    self.underlying = underlying
+  }
+
+  @inlinable
+  public mutating func write<Buffer: RangeReplaceableContainer<WriteElement> & ~Copyable>(
+    buffer: inout Buffer
+  ) async throws(WriteFailure) {
+    var consumer = buffer.consumeAll()
+    while let head = consumer.next() {
+      var pending: WriteElement? = head
+      do throws(EitherError<WriteFailure, Never>) {
+        try await self.underlying.write {
+          (innerBuffer: inout Underlying.Buffer) async throws(Never) -> Void in
+          if case .some(let element) = pending.take() {
+            innerBuffer.append(element)
+          }
+          while innerBuffer.freeCapacity > 0 {
+            guard let element = consumer.next() else { return }
+            innerBuffer.append(element)
+          }
+        }
+      } catch {
+        switch error {
+        case .first(let writeFailure): throw writeFailure
+        case .second: fatalError("Unreachable")
+        }
+      }
+    }
+  }
+
+  @inlinable
+  public consuming func finish<Buffer: RangeReplaceableContainer<WriteElement> & ~Copyable>(
+    buffer: inout Buffer,
+    finalElement: consuming FinalElement
+  ) async throws(WriteFailure) {
+    try await self.write(buffer: &buffer)
+    try await self.underlying.finish(finalElement: finalElement)
+  }
+}
+
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+extension AsyncWriter where Self: ~Copyable {
+  /// Adapts this ``AsyncWriter`` to a ``CallerAsyncWriter``.
+  ///
+  /// The returned adapter accepts caller-supplied buffers via
+  /// ``CallerAsyncWriter/write(buffer:)`` and drains them through this
+  /// writer's closure-based ``AsyncWriter/write(_:)``. When this
+  /// writer's buffer fills before the caller's empties, the adapter
+  /// loops with another closure call.
+  ///
+  /// The adapter introduces no buffer of its own.
+  ///
+  /// - Returns: An adapter that conforms to ``CallerAsyncWriter``.
+  @inlinable
+  public consuming func asCallerAsyncWriter() -> AsyncWriterCallerAsyncWriterAdapter<Self> {
+    .init(underlying: self)
+  }
+}
+#endif

--- a/Sources/AsyncStreaming/CallerAsyncWriter/CallerAsyncWriterAsyncWriterAdapter.swift
+++ b/Sources/AsyncStreaming/CallerAsyncWriter/CallerAsyncWriterAsyncWriterAdapter.swift
@@ -1,0 +1,118 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Async Algorithms open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if UnstableAsyncStreaming && compiler(>=6.4)
+public import ContainersPreview
+public import BasicContainers
+
+/// An ``AsyncWriter`` that is implemented in terms of a ``CallerAsyncWriter``.
+///
+/// The adapter allocates a fresh buffer for each ``write(_:)`` call, runs
+/// the body to fill it, and immediately drains it into the underlying
+/// ``CallerAsyncWriter``. Writes are flushed *eagerly*: the adapter does
+/// not defer the most recent buffer to fuse it with ``finish(finalElement:)``.
+///
+/// Eager flushing keeps request/response patterns deadlock-free — a write
+/// is observable to the peer as soon as the underlying writer accepts it.
+/// The trade-off is that fused close (HTTP/2 DATA+END_STREAM coalescing,
+/// and similar) is not available through this adapter; the underlying
+/// ``CallerAsyncWriter/finish(buffer:finalElement:)`` always receives an
+/// empty buffer. Conformers that need fused close should implement
+/// ``AsyncWriter`` directly rather than going through this adapter.
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+public struct CallerAsyncWriterAsyncWriterAdapter<
+  Underlying: CallerAsyncWriter & ~Copyable,
+  Buffer: DynamicContainer<Underlying.WriteElement> & ~Copyable
+>: ~Copyable, AsyncWriter {
+  public typealias WriteElement = Underlying.WriteElement
+  public typealias WriteFailure = Underlying.WriteFailure
+  public typealias FinalElement = Underlying.FinalElement
+
+  @usableFromInline
+  var underlying: Underlying
+
+  @usableFromInline
+  let initialCapacity: Int
+
+  @inlinable
+  init(underlying: consuming Underlying, initialCapacity: Int) {
+    self.underlying = underlying
+    self.initialCapacity = initialCapacity
+  }
+
+  @inlinable
+  public mutating func write<Return: ~Copyable, Failure: Error>(
+    _ body: (inout Buffer) async throws(Failure) -> Return
+  ) async throws(EitherError<WriteFailure, Failure>) -> Return {
+    var buffer = Buffer(minimumCapacity: self.initialCapacity)
+    let result: Return
+    do throws(Failure) {
+      result = try await body(&buffer)
+    } catch {
+      throw .second(error)
+    }
+    do throws(WriteFailure) {
+      try await self.underlying.write(buffer: &buffer)
+    } catch {
+      throw .first(error)
+    }
+    return result
+  }
+
+  @inlinable
+  public consuming func finish(
+    finalElement: consuming FinalElement
+  ) async throws(WriteFailure) {
+    var empty = Buffer()
+    try await self.underlying.finish(buffer: &empty, finalElement: finalElement)
+  }
+}
+
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+extension CallerAsyncWriter where Self: ~Copyable {
+  /// Adapts this ``CallerAsyncWriter`` to an ``AsyncWriter``, using
+  /// ``UniqueArray`` as the buffer container.
+  ///
+  /// Each ``AsyncWriter/write(_:)`` call on the returned adapter
+  /// allocates a fresh buffer, runs the closure to fill it, and
+  /// immediately drains it into this writer. Writes are flushed
+  /// eagerly — see ``CallerAsyncWriterAsyncWriterAdapter`` for the
+  /// trade-off this implies for fused close.
+  ///
+  /// - Parameter initialCapacity: The capacity reserved on each
+  ///   freshly allocated buffer.
+  /// - Returns: An adapter that conforms to ``AsyncWriter``.
+  @inlinable
+  public consuming func asAsyncWriter(
+    initialCapacity: Int = 4096
+  ) -> CallerAsyncWriterAsyncWriterAdapter<Self, UniqueArray<WriteElement>> {
+    .init(underlying: self, initialCapacity: initialCapacity)
+  }
+
+  /// Adapts this ``CallerAsyncWriter`` to an ``AsyncWriter`` with a
+  /// caller-chosen buffer container type.
+  ///
+  /// - Parameters:
+  ///   - bufferType: The container type for buffers handed to the
+  ///     ``AsyncWriter/write(_:)`` body.
+  ///   - initialCapacity: The capacity reserved on each freshly
+  ///     allocated buffer.
+  /// - Returns: An adapter that conforms to ``AsyncWriter``.
+  @inlinable
+  public consuming func asAsyncWriter<Buffer>(
+    bufferOf bufferType: Buffer.Type,
+    initialCapacity: Int = 4096
+  ) -> CallerAsyncWriterAsyncWriterAdapter<Self, Buffer>
+  where Buffer: DynamicContainer<WriteElement> & ~Copyable {
+    .init(underlying: self, initialCapacity: initialCapacity)
+  }
+}
+#endif


### PR DESCRIPTION
## Motivation

It is quite common to have one type of writer and wanting to adapt to the other type of writer.

## Modifications

This PR adds two adapters into either direction between the writers to make conversion seamless.

## Result

It is easy to go from one type of writer to the other type.